### PR TITLE
Update ubuntu install script for php 8.* (default for Ubuntu 22.04)

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -50,7 +50,7 @@ cat wptserver-install/configs/default/beanstalkd | sudo tee /etc/default/beansta
 sudo service beanstalkd restart
 
 #php
-PHPVER=$(find /etc/php/7.* -maxdepth 0 -type d -printf '%f')
+PHPVER=$(find /etc/php/8.* /etc/php/7.* -maxdepth 0 -type d | head -n 1 | tr -d -c 0-9\.)
 cat wptserver-install/configs/php/php.ini | sudo tee /etc/php/$PHPVER/fpm/php.ini
 cat wptserver-install/configs/php/pool.www.conf | sed "s/%USER%/$USER/" | sudo tee /etc/php/$PHPVER/fpm/pool.d/www.conf
 sudo service php$PHPVER-fpm restart


### PR DESCRIPTION
Updated the script to support and prefer PHP 8.* if available. This is the default PHP version on Ubuntu 22.04.

Tested on:
- [x] Ubuntu 22.04
- [x] Ubuntu 20.04
- [x] Ubuntu 18.04.